### PR TITLE
Remove gtfs-rt stopId requirement

### DIFF
--- a/app/gtfs-monitor/monitor/vehiclemonitor.go
+++ b/app/gtfs-monitor/monitor/vehiclemonitor.go
@@ -2,10 +2,11 @@ package monitor
 
 import (
 	"fmt"
-	"github.com/OpenTransitTools/transitcast/business/data/gtfs"
 	"log"
 	"math"
 	"time"
+
+	"github.com/OpenTransitTools/transitcast/business/data/gtfs"
 )
 
 //vehicleMonitorCollection simple wrapper for retrieving, constructing, and expiring old vehicleMonitors
@@ -66,7 +67,7 @@ func (vm *vehicleMonitor) newPosition(log *log.Logger,
 	if position.positionIsSame(vm.lastPosition, 2) {
 		return nil, results
 	}
-	if position.TripId == nil || position.StopId == nil || position.StopSequence == nil || position.VehicleStopStatus.IsUnknown() {
+	if position.TripId == nil || position.StopSequence == nil || position.VehicleStopStatus.IsUnknown() {
 		//non trip monitoring not implemented yet
 		vm.removeStopPosition()
 		return nil, results


### PR DESCRIPTION
It looks like we were requiring StopId to be present in the RT feeds. I've tested a few RT feeds now that don't include StopId but seem to work fine. 

We seem to be getting stopId info from the trip and stop sequence. The explicit stopId seems not to be needed.