### PR TITLE
adjust end_timestamp to be a more compatible value

### DIFF
--- a/business/data/mlmodels/mlmodels.go
+++ b/business/data/mlmodels/mlmodels.go
@@ -63,7 +63,7 @@ func MakeMLModel(modelType *MLModelType,
 	return &MLModel{
 		Version:           version,
 		StartTimestamp:    at,
-		EndTimestamp:      time.Date(9999, 12, 31, 23, 29, 59, 0, at.Location()),
+		EndTimestamp:      time.Date(3000, 12, 31, 23, 29, 59, 0, at.Location()),
 		MLModelTypeId:     modelType.MLModelTypeId,
 		TrainFlag:         true,
 		CurrentlyRelevant: true,


### PR DESCRIPTION
Setting `end_timestamp` to 10000 causes some issues with the Python part of the code -- changing the year to 3000 instead of 10000 resolves this issue.