### PR TITLE
use correct gtfs-rt feed version

### DIFF
--- a/business/data/gtfsrtproto/gtfs-realtime.proto
+++ b/business/data/gtfsrtproto/gtfs-realtime.proto
@@ -57,7 +57,7 @@ message FeedMessage {
 message FeedHeader {
   // Version of the feed specification.
   // The current version is 2.0.
-  required string gtfs_realtime_version = 1;
+  required string gtfs_realtime_version = 2.0;
 
   // Determines whether the current fetch is incremental.  Currently,
   // DIFFERENTIAL mode is unsupported and behavior is unspecified for feeds


### PR DESCRIPTION
The [GTFS rt spec](https://developers.google.com/transit/gtfs-realtime/reference#fields_2) states that the current feed specification version is "2.0". We were returning "1". This PR corrects this and subsequently makes the output feed compatible with apps that were otherwise upset with the output.